### PR TITLE
Add NRI 832 Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Lastly, if you are into JavaScript, you might enjoy [Echo JS](http://www.echojs.
 - [JsPspEmu](http://jspspemu.com) - JavaScript PSP emulator ([Source](https://github.com/jspspemu/jspspemu))
 - [NanoWasp](http://www.nanowasp.org) - A MicroBee emulator
 - [Nascom 2 emulator](http://thorn.ws/jsnascom/jsnascom.html) by Tommy Thorn. (J to start Basic) ([Source](https://github.com/tommythorn/jsnascom))
+- [NRI 832 Emulator](http://www.robsons.org.uk/nri832/index.html?code=0BE00CE0E3C9E04C83E0E70705) by Paul Robson. (See [blog](http://nri832.blogspot.co.uk/2012/07/javascript-nri832-now-running.html) for source.)
 - PC-01 Lviv - An emulator for the PC-01 Lviv (Ukrainian home computer) ([Source](https://github.com/dolgarev/emulator-pc01-lviv))
 - [Radio-86RK](http://rk86.ru) Radio-86RK emulator in JavaScript (Intel 8080 based 8-bit Russian home computer) ([Source](https://github.com/begoon/rk86-js))
 - [KM-Z80 web](http://hp.vector.co.jp/authors/VA016157/kmz80web10/kmz80web.html) emulator for Sharp MZ-80K, by Katsumi Morimatsu. GOTO $1200 to start KM-BASIC. ([More information](http://hp.vector.co.jp/authors/VA016157/kmz80web10/))


### PR DESCRIPTION
"The National Radio Institute 832 was probably the first commercially available computer kit, built out of standard TTL Logic gates, about 75 of them. It operates at 250Hz (fast mode) or 2Hz (slow mode)"