### PR TITLE
Add link to merry8 emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Lastly, if you are into JavaScript, you might enjoy [Echo JS](http://www.echojs.
 - [Chip-8 virtual machine](http://biged.github.io/Chip-8-Emulator/) by Alexander Dickson - see [blog entry](http://blog.alexanderdickson.com/javascript-chip-8-emulator)
 - [Chip-8 virtual machine](http://pachisystems.com/JSEmu/chip8.html) by Brian Milton ([Source](https://github.com/PachiSystems/JSEmu) may target several CPUs)
 - [Chip8 1k](http://xem.github.io/chip8/) - a code-golfed chip 8 emulator in 1k by Maxime Euzière and others
+- [Merry8](https://github.com/doodlewind/merry8) - JavaScript Chip-8 emulator by Yifeng Wang
 - [Compucolor II Emulator](http://compucolor.org/emu/ccemu.html) - JavaScript Compucolor II Emulator
 - [Compukit UK101](http://www.avoncliff.com/uk101/) - by David Stevenson
 - [ContrAltoJS](http://www.loomcom.com/contraltojs/) - Pure JavaScript implementation of the ContrAlto Xerox Alto emulator ([Source](https://github.com/sethm/ContrAltoJS))


### PR DESCRIPTION
This PR adds a link to my Chip-8 emulator [merry8](https://github.com/doodlewind/merry8) 😄