### PR TITLE
Fix the source code link to Acorn Atom emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Lastly, if you are into JavaScript, you might enjoy [Echo JS](http://www.echojs.
 
 ## Acorn
 
-- [Acorn Atom](https://floooh.github.io/tiny8bit/atom.html) - by Andre Weissflog ([Source](https://github.com/floooh/tiny8bit))
+- [Acorn Atom](https://floooh.github.io/tiny8bit/atom.html) - by Andre Weissflog ([Source](https://github.com/floooh/chips))
 - [Acorn Atom Emulator](http://phils-place.co.uk/HTeMuLator/atom/) - by Phil Mainwaring. Type "OLD" for an Easter Egg
 - [ElkJS](http://elkjs.azurewebsites.net/) - JavaScript based Acorn Electron emulator ([Source](https://github.com/dmcoles/elkjs))
 - [JSBeeb](http://bbc.godbolt.org) - JavaScript BBC Micro emulator ([Source](https://github.com/mattgodbolt/jsbeeb)) ([Development blog](http://xania.org/Emulation))


### PR DESCRIPTION
This PR fixes the source link to my Acorn Atom emulator. The originally provided link was pointing to the github-pages repository, which only contained the compiled WebAssembly blobs.