### PR TITLE
Fix Jupiler link

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ adding them to the collection: the source for this page is available on
 - [jsMSX](http://jsmsx.sourceforge.net/) - The first MSX emulator 100% written in JavaScript
 - [JsPspEmu](http://jspspemu.com) - JavaScript PSP emulator ([Source](https://github.com/jspspemu/jspspemu))
 - [JSVecX](http://www.twitchasylum.com/jsvecx/) - JavaScript port of the VecX Vectrex emulator
-- [jupiler](https://jupiler.antoniovillena.es/) - Jupiter Ace emulator written in JavaScript ([Source](https://sourceforge.net/p/emuscriptoria/code/HEAD/tree/jupiler.js))
+- [jupiler](http://jupiler.zxtres.com) - Jupiter Ace emulator written in JavaScript ([Source](https://sourceforge.net/p/emuscriptoria/code/HEAD/tree/jupiler.js))
 - [KM-Z80 web](http://hp.vector.co.jp/authors/VA016157/kmz80web10/kmz80web.html) emulator for Sharp MZ-80K, by Katsumi Morimatsu. GOTO $1200 to start KM-BASIC. ([More information](http://hp.vector.co.jp/authors/VA016157/kmz80web10/))
 - [laser500emu](https://nippur72.github.io/laser500emu/) emulator for Video Technology (VTech) Laser 350/500/700, by Antonino Porcino.
 - [Little Man Computer](http://matt.krutar.org/LMC4/) a minimal CPU for teaching - emulator by Matthew Krutar. ([Background](https://en.wikipedia.org/wiki/Little_man_computer))


### PR DESCRIPTION
Antonio Villena provided new working address for the Jupiler: http://jupiler.zxtres.com/