### PR TITLE
Add PicoBlaze assembler and emulator link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ adding them to the collection: the source for this page is available on
 - [iRISC](https://polysoftit.co.uk/irisc-web/) - Interactive ARMv7 assembly language interpreter and computer architecture simulator ([Source](https://github.com/rtybanana/irisc-web/))
 - [JavaScript 8080 Emulator](https://bluishcoder.co.nz/js8080/) - 8080 arcade game emulator in JavaScript
 - [Mipsdis](http://blog.loadzero.com/demo/mipsdis/demo.html) - MIPS disassembler that runs in the browser
+- [PicoBlaze assembler and emulator in JavaScript](https://picoblaze-simulator.sourceforge.io/) - An assembler and an emulator for the [Xilinx PicoBlaze soft-processor](https://en.wikipedia.org/wiki/PicoBlaze), made by Teo Samaržija, Agustín Izaguirre, and Abidin Durdu ([Source](https://github.com/FlatAssembler/PicoBlaze_Simulator_in_JS))
 - [RISC Relay Computer](https://www.enscope.nl/rrca/) - Relay based computer project with a 16 bit RISC CPU. Emulator includes an assembler and source for a calculator program. By RJH. See [website](http://www.enscope.nl/rrc).
 - [RISCVEMU](https://bellard.org/riscvemu/js/) - RISC-V emulator boots 64-bit Linux. By Fabrice Bellard.
 - [RP2040js](https://wokwi.com/arduino/projects/297323005822894602) - Raspberry Pi Pico (RP2040 / Arm Cortex-M0+) emulator with C/C++/MicroPython/CircuitPython support ([Source](https://github.com/wokwi/rp2040js))


### PR DESCRIPTION
Hello there!
I and a few other GitHub users have been working on an assembler and an emulator for the Xilinx PicoBlaze written in JavaScript, and I therefore believe it belongs to this list.