### PR TITLE
Add wine-assembly to PC Emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ adding them to the collection: the source for this page is available on
 - [jemul8](http://jemul8.com) - An object-oriented JavaScript x86 emulator for Node.js and the Browser ([Source](https://github.com/asmblah/jemul8))
 - jsbochs - Bochs PC emulator for the Browser ([Source](https://github.com/codinguncut/jsbochs))
 - [Boxedwine](http://www.boxedwine.org/) - An emulator that runs Windows applications using Wine and emulating a Linux kernel and CPU ([Source](https://github.com/danoon2/Boxedwine))
+- [wine-assembly](https://wine-assembly.berrry.app) - Runs real Windows 98 executables in the browser via a WAT-native x86 interpreter (no Rust/C/Emscripten toolchain) ([Source](https://github.com/vgrichina/wine-assembly))
 
 ## Bare CPUs
 


### PR DESCRIPTION
Adds wine-assembly to the PC Emulators section.

wine-assembly is an x86 interpreter authored directly as WebAssembly Text (WAT) — no Rust/C/Emscripten compilation step. It loads real Win32 PE executables (Pinball, SkiFree, Winamp, mspaint, FreeCell, Solitaire, Space Cadet Pinball, etc.) and runs them in the browser without OS emulation.

- **Live demo:** https://wine-assembly.berrry.app
- **Source:** https://github.com/vgrichina/wine-assembly
- **License:** MIT

Differs from existing PC Emulators entries:
- v86 / Halfix / QemuJS / jsbochs: emulate full PC hardware + boot a guest OS image
- Boxedwine: emulates a Linux kernel + CPU to host Wine
- wine-assembly: loads PE binaries directly — no kernel, no disk image, no compiler in the toolchain